### PR TITLE
Dispatched signals should not throw

### DIFF
--- a/src/signal.ts
+++ b/src/signal.ts
@@ -15,6 +15,12 @@ export class Signal<T> extends ExtendedSignal<T> implements WritableSignal<T> {
         });
     }
     public dispatch(payload: T): void {
-        this._listeners.forEach(callback => callback.call(undefined, payload));
+        this._listeners.forEach(callback => {
+            try {
+                callback.call(undefined, payload);
+                // tslint:disable-next-line:no-empty
+            } catch (e) {
+            }
+        });
     }
 }

--- a/test/signal.spec.ts
+++ b/test/signal.spec.ts
@@ -28,6 +28,31 @@ test('Signal listeners should received dispatched payloads', t => {
     t.end();
 });
 
+test('All listeners should receive dispatched payloads even with exceptions', t => {
+    const signal = new Signal<string>();
+
+    const sentPayloads = ['a', 'b', 'c'];
+
+    const receivedPayloadsListener1: string[] = [];
+    const receivedPayloadsListener2: string[] = [];
+
+    signal.add(payload => {
+        receivedPayloadsListener1.push(payload);
+        throw new Error('');
+    });
+    signal.add(payload => {
+        receivedPayloadsListener2.push(payload);
+        throw new Error('');
+    });
+
+    sentPayloads.forEach(payload => signal.dispatch(payload));
+
+    t.deepEqual(receivedPayloadsListener1, sentPayloads);
+    t.deepEqual(receivedPayloadsListener2, sentPayloads);
+
+    t.end();
+});
+
 test('Signal listener should be called only once when using addOnce', t => {
     const signal = new Signal<void>();
     let callCount = 0;


### PR DESCRIPTION
Hi Leland,

I think that dispatching signals should

a) not leak exceptions in the signal handlers to the caller
b) ensure that all registered signal handlers receive the signal

I hope you accept the pull request.

-- Michael