### PR TITLE
Support type predicates for filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,27 @@ filteredSignal.add(payload => {
 assert.deepEqual(received, [0, 6, 8, 0]);
 ```
 
+Signal.filter also returns a signal of the correct type when filtering using a type predicate.
+
+```ts
+import {Signal} from 'micro-signals';
+import * as assert from 'assert';
+
+const signal = new Signal<string | null>();
+const filteredSignal = signal.filter((x: string | null): x is string => typeof x === 'string');
+
+const received: number[] = [];
+
+filteredSignal.add(payload => {
+    // note that the payload type is `string` instead of `string | null`
+    received.push(payload.length);
+});
+
+['1', null, '12', null, '123'].forEach(x => signal.dispatch(x));
+
+assert.deepEqual(received, [1, 2, 3]);
+```
+
 ### Signal.map
 
 Signal.map provides the ability to transform payloads coming through a Signal, similar to mapping an

--- a/src/extended-signal.ts
+++ b/src/extended-signal.ts
@@ -71,6 +71,8 @@ export class ExtendedSignal<T> implements ReadableSignal<T> {
         this._addOnceListenerMap.set(listener, oneTimeListener);
         this._baseSignal.add(oneTimeListener);
     }
+    public filter<U extends T>(filter: (payload: T) => payload is U): ReadableSignal<U>;
+    public filter(filter: (payload: T) => boolean): ReadableSignal<T>;
     public filter(filter: (payload: T) => boolean): ReadableSignal<T> {
         return new ExtendedSignal(
             convertedListenerSignal(

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,6 +7,7 @@ export interface BaseSignal<T> {
 
 export interface ReadableSignal<T> extends BaseSignal<T> {
     addOnce(listener: Listener<T>): void;
+    filter<U extends T>(filter: (payload: T) => payload is U): ReadableSignal<U>;
     filter(filter: (payload: T) => boolean): ReadableSignal<T>;
     map<U>(transform: (payload: T) => U): ReadableSignal<U>;
     merge<U>(...signals: ReadableSignal<U>[]): ReadableSignal<T|U>;

--- a/test/signal.spec.ts
+++ b/test/signal.spec.ts
@@ -1,6 +1,7 @@
 import test = require('tape');
 
 import {
+    ReadableSignal,
     Signal,
 } from '../src';
 
@@ -76,6 +77,27 @@ test('Signal listener should be called only once when using addOnce', t => {
     }
 
     t.equal(callCount, 1);
+
+    t.end();
+});
+
+/**
+ * This tests the type of the filter function exclusively. There is no runtime assertion in this
+ * test, but this test will fail the TypeScript typechecker if we have broken this functionality.
+ */
+test('filter types should allow for filtering using type predicates correctly', t => {
+    function isString(x: any): x is string {
+        return typeof x === 'string';
+    }
+
+    const signal = new Signal<undefined | string>();
+    const readableSignal: ReadableSignal<undefined | string> = new Signal();
+
+    const filteredSignal = signal.filter(isString);
+    const filteredReadableSignal = readableSignal.filter(isString);
+
+    filteredSignal.add(s => s.length);
+    filteredReadableSignal.add(s => s.length);
 
     t.end();
 });


### PR DESCRIPTION
This allows filter to return a signal with the correct type when
attempting to filter payloads of a certain type.