### PR TITLE
Remove WritableSignal extension of ReadableSignal

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -14,7 +14,6 @@ export interface ReadableSignal<T> extends BaseSignal<T> {
     readOnly(): ReadableSignal<T>;
 }
 
-// TODO Writable should only be writable
-export interface WritableSignal<T> extends ReadableSignal<T> {
+export interface WritableSignal<T> {
     dispatch: (payload: T) => void;
 }

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -1,8 +1,9 @@
 import {Listener, WritableSignal} from './interfaces';
 
 import {ExtendedSignal} from './extended-signal';
+import { ReadableSignal } from './index';
 
-export class Signal<T> extends ExtendedSignal<T> implements WritableSignal<T> {
+export class Signal<T> extends ExtendedSignal<T> implements WritableSignal<T>, ReadableSignal<T> {
     protected _listeners = new Set<Listener<T>>();
     constructor() {
         super({

--- a/test/suites/parent-child-suite.ts
+++ b/test/suites/parent-child-suite.ts
@@ -1,9 +1,9 @@
 import test = require('tape');
 
-import { BaseSignal, WritableSignal } from '../../src';
+import { BaseSignal, ReadableSignal, WritableSignal } from '../../src';
 
 export interface SignalSet {
-    parentSignal: WritableSignal<any>;
+    parentSignal: ReadableSignal<any> & WritableSignal<any>;
     childSignal: BaseSignal<any>;
 }
 


### PR DESCRIPTION
This matches the previous state of the interfaces and allows more
control over signal access. This also matches what is described in the
README. This means the WritableSignal only describes the dispatch
method.