### PR TITLE
RFC: register special exception handlers

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,8 +1,11 @@
 export type Listener<T> = (payload: T) => void;
+export type Catcher = (error: any) => void;
 
 export interface BaseSignal<T> {
     add(listener: Listener<T>, ...tags: any[]): void;
     remove(listenerOrTag: any): void;
+    catch(catcher: Catcher, ...tags: any[]): void;
+    removeCatcher(listenerOrTag: any): void;
 }
 
 export interface ReadableSignal<T> extends BaseSignal<T> {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -4,11 +4,16 @@ export type Catcher = (error: any) => void;
 export interface BaseSignal<T> {
     add(listener: Listener<T>, ...tags: any[]): void;
     remove(listenerOrTag: any): void;
+}
+
+export interface CatchingSignal<T> extends BaseSignal<T> {
+    add(listener: Listener<T>, ...tags: any[]): void;
+    remove(listenerOrTag: any): void;
     catch(catcher: Catcher, ...tags: any[]): void;
     removeCatcher(listenerOrTag: any): void;
 }
 
-export interface ReadableSignal<T> extends BaseSignal<T> {
+export interface ReadableSignal<T> extends CatchingSignal<T> {
     addOnce(listener: Listener<T>, ...tags: any[]): void;
     filter<U extends T>(filter: (payload: T) => payload is U): ReadableSignal<U>;
     filter(filter: (payload: T) => boolean): ReadableSignal<T>;

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -30,8 +30,13 @@ export class Signal<T> extends ExtendedSignal<T> implements WritableSignal<T>, R
             instanceDefaultListener(payload);
             return;
         }
-
-        this._listeners.forEach(callback => callback.call(undefined, payload));
+        this._listeners.forEach(callback => {
+            try {
+                callback.call(undefined, payload);
+                // tslint:disable-next-line:no-empty
+            } catch (e) {
+            }
+        });
     }
 
     public setDefaultListener(listener: Listener<T>) {

--- a/src/tag-map.ts
+++ b/src/tag-map.ts
@@ -1,32 +1,35 @@
-import {Listener} from './interfaces';
 
-export class TagMap<T> {
-    private _tagToListeners = new WeakMap<any, Set<Listener<T>>>();
-    private _listenerToTags = new WeakMap<Listener<T>, Set<any>>();
-    public setListeners(listener: Listener<T>, ...tags: any[]) {
-        const tagSet = this._listenerToTags.get(listener) || new Set();
+export class TagMap<Thing extends object> {
+    private _tagToThings = new WeakMap<any, Set<Thing>>();
+    private _thingToTags = new WeakMap<Thing, Set<any>>();
+
+    public setHandlers(thing: Thing, ...tags: any[]) {
+        const tagSet = this._thingToTags.get(thing) || new Set();
         tags.forEach(tag => {
-            const listenerSet = this._tagToListeners.get(tag) || new Set();
-            listenerSet.add(listener);
+            const thingSet = this._tagToThings.get(tag) || new Set();
+            thingSet.add(thing);
             tagSet.add(tag);
-            this._tagToListeners.set(tag, listenerSet);
+            this._tagToThings.set(tag, thingSet);
         });
-        this._listenerToTags.set(listener, tagSet);
+        this._thingToTags.set(thing, tagSet);
     }
-    public getListeners(tag: any): Set<Listener<T>> {
-        return this._tagToListeners.get(tag) || new Set();
+
+    public getThings(tag: any): Set<Thing> {
+        return this._tagToThings.get(tag) || new Set();
     }
-    public getTags(listener: Listener<T>): Set<any> {
-        return this._listenerToTags.get(listener) || new Set();
+
+    public getTags(listener: Thing): Set<any> {
+        return this._thingToTags.get(listener) || new Set();
     }
-    public clearListener(listener: Listener<T>) {
-        const tags = this.getTags(listener);
-        this._listenerToTags.delete(listener);
+
+    public clearThing(handler: Thing) {
+        const tags = this.getTags(handler);
+        this._thingToTags.delete(handler);
         tags.forEach(tag => {
-            const listenerSet = this.getListeners(tag);
-            listenerSet.delete(listener);
+            const listenerSet = this.getThings(tag);
+            listenerSet.delete(handler);
             if (listenerSet.size === 0) {
-                this._tagToListeners.delete(tag);
+                this._tagToThings.delete(tag);
             }
         });
     }

--- a/test/signal.spec.ts
+++ b/test/signal.spec.ts
@@ -138,6 +138,7 @@ test('Catchers should receive no exceptions after being removed', t => {
     t.end();
 });
 
+// FIXME: actually for filtered the handlers shouldn't be called at all
 test('Catchers should receive exceptions for derived Signals too', t => {
     const signal = new Signal<number>();
     const filtered = signal.filter(x => x > 2);
@@ -158,7 +159,7 @@ test('Catchers should receive exceptions for derived Signals too', t => {
     ];
 
     signal.catch(exception => receivedExceptions1.push(exception));
-    filtered.catch(exception => receivedExceptions2.push(exception));
+    filtered.catch!(exception => receivedExceptions2.push(exception));
 
     signal.add(() => { throw e1; });
     filtered.add(() => { throw e2; });
@@ -172,6 +173,29 @@ test('Catchers should receive exceptions for derived Signals too', t => {
     t.deepEqual(receivedExceptions2, expectedExceptions);
     t.deepEqual(receivedPayloadsListener1, [1, 2, 3, 4]);
     t.deepEqual(receivedPayloadsListener2, [3, 4]);
+
+    t.end();
+});
+
+test('Filtered Signals shouldn\'t call listeners at all', t => {
+    const signal = new Signal<number>();
+    const filtered = signal.filter(_x => false);
+
+    const e = new Error('error2');
+
+    const receivedExceptions: Error[] = [];
+    const receivedPayloadsListener: number[] = [];
+
+    const expectedExceptions: Error[] = [];
+
+    filtered.catch!(exception => receivedExceptions.push(exception));
+    filtered.add(() => { throw e; });
+    filtered.add(payload => receivedPayloadsListener.push(payload));
+
+    [1, 2, 3, 4].forEach(x => signal.dispatch(x));
+
+    t.deepEqual(receivedExceptions, expectedExceptions);
+    t.deepEqual(receivedPayloadsListener, []);
 
     t.end();
 });

--- a/test/signal.spec.ts
+++ b/test/signal.spec.ts
@@ -66,6 +66,31 @@ test('Signal listeners should received dispatched payloads', t => {
     t.end();
 });
 
+test('All listeners should receive dispatched payloads even with exceptions', t => {
+    const signal = new Signal<string>();
+
+    const sentPayloads = ['a', 'b', 'c'];
+
+    const receivedPayloadsListener1: string[] = [];
+    const receivedPayloadsListener2: string[] = [];
+
+    signal.add(payload => {
+        receivedPayloadsListener1.push(payload);
+        throw new Error('');
+    });
+    signal.add(payload => {
+        receivedPayloadsListener2.push(payload);
+        throw new Error('');
+    });
+
+    sentPayloads.forEach(payload => signal.dispatch(payload));
+
+    t.deepEqual(receivedPayloadsListener1, sentPayloads);
+    t.deepEqual(receivedPayloadsListener2, sentPayloads);
+
+    t.end();
+});
+
 test('Signal listener should be called only once when using addOnce', t => {
     const signal = new Signal<void>();
     let callCount = 0;


### PR DESCRIPTION
A Signal now has `.catch((e: any) => void)`. Catchers are essentially listeners for exceptions thrown by other listeners. They themselves no longer catch anything, ergo a throw in a catcher is your own problem again.

### Open Questions
* [ ] what about promisified signals?
* [ ] do we want to have `.removeCatcher(catcher|tag)`?
* [ ] wouldn't `.add(listener, catcherOnlyForThisListener)` be nice?
* [ ] what about `.catchOnce()` or `filterCatch()`
* [ ] at what point are these no longer _micro_-signals?