### PR TITLE
helper types

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -32,5 +32,8 @@ export interface Cache<T> {
 
 export type Accumulator<T, U> = (accum: U, current: T) => any;
 
+export type PayloadOf<S extends BaseSignal<any>> =
+    S extends BaseSignal<infer T> ? T : never;
+
 export type ReadOnlyVersionOf<S extends BaseSignal<any>> =
     S extends BaseSignal<infer T> ? ReadableSignal<T> : never;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,3 +31,6 @@ export interface Cache<T> {
 }
 
 export type Accumulator<T, U> = (accum: U, current: T) => any;
+
+export type ReadOnlyVersionOf<S extends BaseSignal<any>> =
+    S extends BaseSignal<infer T> ? ReadableSignal<T> : never;

--- a/test/suites/read-only-suite.ts
+++ b/test/suites/read-only-suite.ts
@@ -3,7 +3,7 @@ import test = require('tape');
 import {LeakDetectionSignal} from '../lib/leak-detection-signal';
 import {parentChildSuite} from './parent-child-suite';
 
-import {ReadableSignal, Signal} from '../../src';
+import {ReadableSignal, ReadOnlyVersionOf, Signal} from '../../src';
 
 export type ReadOnlySignalCreationFunction = <T>(baseSignal: ReadableSignal<T>) => ReadableSignal<T>;
 
@@ -59,6 +59,22 @@ export function readOnlySuite(prefix: string, createReadOnlySignal: ReadOnlySign
         readOnlySignal.remove(listener);
 
         t.equal(signal.listenerCount, 0);
+        t.end();
+    });
+
+    test(`${prefix} should compile`, t => {
+        interface FooBar {
+            foo: 'foo';
+            bar: 'bar';
+        }
+
+        const takesFooBar = (_fb: FooBar) => void 0;
+
+        const writable = new Signal<FooBar>();
+        const readonly: ReadOnlyVersionOf<typeof writable> = writable.readOnly();
+
+        readonly.add(takesFooBar);
+
         t.end();
     });
 

--- a/test/suites/read-only-suite.ts
+++ b/test/suites/read-only-suite.ts
@@ -3,7 +3,7 @@ import test = require('tape');
 import {LeakDetectionSignal} from '../lib/leak-detection-signal';
 import {parentChildSuite} from './parent-child-suite';
 
-import {ReadableSignal, ReadOnlyVersionOf, Signal} from '../../src';
+import {PayloadOf, ReadableSignal, ReadOnlyVersionOf, Signal} from '../../src';
 
 export type ReadOnlySignalCreationFunction = <T>(baseSignal: ReadableSignal<T>) => ReadableSignal<T>;
 
@@ -72,6 +72,8 @@ export function readOnlySuite(prefix: string, createReadOnlySignal: ReadOnlySign
 
         const writable = new Signal<FooBar>();
         const readonly: ReadOnlyVersionOf<typeof writable> = writable.readOnly();
+        const payload: PayloadOf<typeof writable> = {foo: 'foo' , bar: 'bar'};
+        writable.dispatch(payload);
 
         readonly.add(takesFooBar);
 


### PR DESCRIPTION
Hi there, I found myself writing something like this occasionally, so I though maybe it could be useful here.

```ts
const someSignal = new Signal<'string`>();
const x: PayloadOf<typeof SomeSignal> // x is of type 'string'
const y: ReadOnlyVersionOf<typeof SomeSignal> // x is of type ReadableSignal<'string'>
```